### PR TITLE
Update node config for K8s 1.16.3

### DIFF
--- a/examples/node.yaml
+++ b/examples/node.yaml
@@ -30,7 +30,7 @@ kind: ServiceAccount
 metadata:
   name: kube-stresscheck
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: kube-stresscheck-psp
@@ -49,13 +49,16 @@ spec:
   - 'secret'
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: kube-stresscheck
   namespace: kube-system
   labels:
     app: kube-stresscheck
 spec:
+  selector:
+    matchLabels:
+      app: kube-stresscheck
   template:
     metadata:
       labels:


### PR DESCRIPTION
The `node.yaml` file does not work out of the box for Kubernetes 1.16.3.

This PR fixes that.

But I don't know if it is wanted to use old resources definitions, for old Kubernetes versions.