### PR TITLE
Adding namespace to serviceaccount

### DIFF
--- a/examples/node.yaml
+++ b/examples/node.yaml
@@ -29,6 +29,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-stresscheck
+  namespace: kube-system
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy


### PR DESCRIPTION
Running this manifest results in "missing serviceaccount" errors within kube-system. Updating to resolve serviceaccount 'default' vs 'kube-system'.